### PR TITLE
Add approval workflow data models

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # gptshenpi
+
+This repository provides core data models for an approval workflow system.
+Models are defined using [SQLAlchemy](https://www.sqlalchemy.org/) in the
+`models` directory. These models cover users, organizations, departments,
+approval templates, forms, records and notifications to support approval
+processing, delegation and push notifications.

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,0 +1,28 @@
+from .base import Base
+from .admin import Admin
+from .user import User
+from .organization import Organization
+from .department import Department
+from .approval_template import ApprovalTemplate
+from .approval_form import ApprovalForm, FormStatus
+from .approval_record import ApprovalRecord, ActionType
+from .submission_record import SubmissionRecord
+from .verification_record import VerificationRecord, VerificationStatus
+from .notification import Notification
+
+__all__ = [
+    "Base",
+    "Admin",
+    "User",
+    "Organization",
+    "Department",
+    "ApprovalTemplate",
+    "ApprovalForm",
+    "FormStatus",
+    "ApprovalRecord",
+    "ActionType",
+    "SubmissionRecord",
+    "VerificationRecord",
+    "VerificationStatus",
+    "Notification",
+]

--- a/models/admin.py
+++ b/models/admin.py
@@ -1,0 +1,17 @@
+from sqlalchemy import Column, Integer, ForeignKey, String, Boolean, Index
+from sqlalchemy.orm import relationship
+
+from .base import Base, TimestampMixin
+
+
+class Admin(TimestampMixin, Base):
+    __tablename__ = "admins"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    role = Column(String(50), nullable=False, default="admin")
+    is_super = Column(Boolean, default=False, nullable=False)
+
+    user = relationship("User", back_populates="admin")
+
+    __table_args__ = (Index("ix_admin_user_id", "user_id"),)

--- a/models/approval_form.py
+++ b/models/approval_form.py
@@ -1,0 +1,50 @@
+from enum import Enum as PyEnum
+
+from sqlalchemy import (
+    Column,
+    Integer,
+    ForeignKey,
+    JSON,
+    Enum,
+    Index,
+)
+from sqlalchemy.orm import relationship
+
+from .base import Base, TimestampMixin
+
+
+class FormStatus(PyEnum):
+    PENDING = "pending"
+    APPROVED = "approved"
+    REJECTED = "rejected"
+    CANCELLED = "cancelled"
+
+
+class ApprovalForm(TimestampMixin, Base):
+    __tablename__ = "approval_forms"
+
+    id = Column(Integer, primary_key=True)
+    template_id = Column(Integer, ForeignKey("approval_templates.id"), nullable=False)
+    applicant_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    department_id = Column(Integer, ForeignKey("departments.id"))
+    status = Column(Enum(FormStatus), default=FormStatus.PENDING, nullable=False)
+    data = Column(JSON, nullable=False)
+
+    template = relationship("ApprovalTemplate", back_populates="forms")
+    applicant = relationship("User", back_populates="approval_forms")
+    department = relationship("Department", back_populates="approval_forms")
+    approval_records = relationship(
+        "ApprovalRecord", back_populates="form", cascade="all, delete-orphan"
+    )
+    submission_records = relationship(
+        "SubmissionRecord", back_populates="form", cascade="all, delete-orphan"
+    )
+    verification_records = relationship(
+        "VerificationRecord", back_populates="form", cascade="all, delete-orphan"
+    )
+
+    __table_args__ = (
+        Index("ix_form_template", "template_id"),
+        Index("ix_form_applicant", "applicant_id"),
+        Index("ix_form_status", "status"),
+    )

--- a/models/approval_record.py
+++ b/models/approval_record.py
@@ -1,0 +1,47 @@
+from enum import Enum as PyEnum
+
+from sqlalchemy import (
+    Column,
+    Integer,
+    ForeignKey,
+    Enum,
+    String,
+    DateTime,
+    Index,
+)
+from sqlalchemy.orm import relationship
+
+from .base import Base, TimestampMixin
+
+
+class ActionType(PyEnum):
+    APPROVED = "approved"
+    REJECTED = "rejected"
+    DELEGATED = "delegated"
+    SUBMITTED = "submitted"
+
+
+class ApprovalRecord(TimestampMixin, Base):
+    __tablename__ = "approval_records"
+
+    id = Column(Integer, primary_key=True)
+    form_id = Column(Integer, ForeignKey("approval_forms.id"), nullable=False)
+    approver_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    action = Column(Enum(ActionType), nullable=False)
+    comments = Column(String(255))
+    acted_at = Column(DateTime)
+    delegated_to_id = Column(Integer, ForeignKey("users.id"))
+    step = Column(Integer)
+
+    form = relationship("ApprovalForm", back_populates="approval_records")
+    approver = relationship(
+        "User", back_populates="approval_records", foreign_keys=[approver_id]
+    )
+    delegated_to = relationship(
+        "User", back_populates="delegated_records", foreign_keys=[delegated_to_id]
+    )
+
+    __table_args__ = (
+        Index("ix_record_form", "form_id"),
+        Index("ix_record_approver", "approver_id"),
+    )

--- a/models/approval_template.py
+++ b/models/approval_template.py
@@ -1,0 +1,19 @@
+from sqlalchemy import Column, Integer, String, ForeignKey, JSON, Index
+from sqlalchemy.orm import relationship
+
+from .base import Base, TimestampMixin
+
+
+class ApprovalTemplate(TimestampMixin, Base):
+    __tablename__ = "approval_templates"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String(128), nullable=False, unique=True)
+    description = Column(String(255))
+    creator_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    steps = Column(JSON, nullable=False)
+
+    creator = relationship("User")
+    forms = relationship("ApprovalForm", back_populates="template")
+
+    __table_args__ = (Index("ix_template_creator", "creator_id"),)

--- a/models/base.py
+++ b/models/base.py
@@ -1,0 +1,13 @@
+from sqlalchemy.orm import declarative_base
+from sqlalchemy import Column, DateTime, func
+
+Base = declarative_base()
+
+
+class TimestampMixin:
+    """Common timestamp columns."""
+
+    created_at = Column(DateTime, default=func.now(), nullable=False)
+    updated_at = Column(
+        DateTime, default=func.now(), onupdate=func.now(), nullable=False
+    )

--- a/models/department.py
+++ b/models/department.py
@@ -1,0 +1,25 @@
+from sqlalchemy import Column, Integer, String, ForeignKey, Index
+from sqlalchemy.orm import relationship
+
+from .base import Base, TimestampMixin
+
+
+class Department(TimestampMixin, Base):
+    __tablename__ = "departments"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String(128), nullable=False)
+    organization_id = Column(Integer, ForeignKey("organizations.id"), nullable=False)
+    parent_id = Column(Integer, ForeignKey("departments.id"))
+    manager_id = Column(Integer, ForeignKey("users.id"))
+
+    organization = relationship("Organization", back_populates="departments")
+    parent = relationship("Department", remote_side=[id], backref="children")
+    manager = relationship("User")
+    users = relationship("User", back_populates="department")
+    approval_forms = relationship("ApprovalForm", back_populates="department")
+
+    __table_args__ = (
+        Index("ix_dept_org", "organization_id"),
+        Index("ix_dept_parent", "parent_id"),
+    )

--- a/models/notification.py
+++ b/models/notification.py
@@ -1,0 +1,24 @@
+from sqlalchemy import Column, Integer, String, Boolean, ForeignKey, DateTime, Index
+from sqlalchemy.orm import relationship
+
+from .base import Base, TimestampMixin
+
+
+class Notification(TimestampMixin, Base):
+    __tablename__ = "notifications"
+
+    id = Column(Integer, primary_key=True)
+    recipient_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    message = Column(String(255), nullable=False)
+    type = Column(String(50), nullable=False)
+    read = Column(Boolean, default=False, nullable=False)
+    related_form_id = Column(Integer, ForeignKey("approval_forms.id"))
+    pushed_at = Column(DateTime)
+
+    recipient = relationship("User", back_populates="notifications")
+    related_form = relationship("ApprovalForm")
+
+    __table_args__ = (
+        Index("ix_notification_recipient", "recipient_id"),
+        Index("ix_notification_read", "read"),
+    )

--- a/models/organization.py
+++ b/models/organization.py
@@ -1,0 +1,19 @@
+from sqlalchemy import Column, Integer, String, ForeignKey, Index
+from sqlalchemy.orm import relationship
+
+from .base import Base, TimestampMixin
+
+
+class Organization(TimestampMixin, Base):
+    __tablename__ = "organizations"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String(128), nullable=False, unique=True)
+    description = Column(String(255))
+    parent_id = Column(Integer, ForeignKey("organizations.id"))
+
+    parent = relationship("Organization", remote_side=[id], backref="children")
+    departments = relationship("Department", back_populates="organization")
+    users = relationship("User", back_populates="organization")
+
+    __table_args__ = (Index("ix_org_parent", "parent_id"),)

--- a/models/submission_record.py
+++ b/models/submission_record.py
@@ -1,0 +1,21 @@
+from sqlalchemy import Column, Integer, ForeignKey, DateTime, Index
+from sqlalchemy.orm import relationship
+
+from .base import Base, TimestampMixin
+
+
+class SubmissionRecord(TimestampMixin, Base):
+    __tablename__ = "submission_records"
+
+    id = Column(Integer, primary_key=True)
+    form_id = Column(Integer, ForeignKey("approval_forms.id"), nullable=False)
+    submitter_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    submitted_at = Column(DateTime)
+
+    form = relationship("ApprovalForm", back_populates="submission_records")
+    submitter = relationship("User", back_populates="submission_records")
+
+    __table_args__ = (
+        Index("ix_submission_form", "form_id"),
+        Index("ix_submission_submitter", "submitter_id"),
+    )

--- a/models/user.py
+++ b/models/user.py
@@ -1,0 +1,37 @@
+from sqlalchemy import Column, Integer, String, Boolean, ForeignKey, Index
+from sqlalchemy.orm import relationship
+
+from .base import Base, TimestampMixin
+
+
+class User(TimestampMixin, Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True)
+    username = Column(String(64), nullable=False, unique=True)
+    email = Column(String(128), unique=True)
+    password_hash = Column(String(128), nullable=False)
+    organization_id = Column(Integer, ForeignKey("organizations.id"))
+    department_id = Column(Integer, ForeignKey("departments.id"))
+    is_active = Column(Boolean, default=True)
+
+    organization = relationship("Organization", back_populates="users")
+    department = relationship("Department", back_populates="users")
+    admin = relationship("Admin", uselist=False, back_populates="user")
+    approval_forms = relationship("ApprovalForm", back_populates="applicant")
+    approval_records = relationship(
+        "ApprovalRecord", back_populates="approver", foreign_keys="ApprovalRecord.approver_id"
+    )
+    delegated_records = relationship(
+        "ApprovalRecord",
+        back_populates="delegated_to",
+        foreign_keys="ApprovalRecord.delegated_to_id",
+    )
+    submission_records = relationship("SubmissionRecord", back_populates="submitter")
+    verification_records = relationship("VerificationRecord", back_populates="verifier")
+    notifications = relationship("Notification", back_populates="recipient")
+
+    __table_args__ = (
+        Index("ix_user_org", "organization_id"),
+        Index("ix_user_dept", "department_id"),
+    )

--- a/models/verification_record.py
+++ b/models/verification_record.py
@@ -1,0 +1,31 @@
+from enum import Enum as PyEnum
+
+from sqlalchemy import Column, Integer, ForeignKey, DateTime, Enum, String, Index
+from sqlalchemy.orm import relationship
+
+from .base import Base, TimestampMixin
+
+
+class VerificationStatus(PyEnum):
+    PENDING = "pending"
+    VERIFIED = "verified"
+    FAILED = "failed"
+
+
+class VerificationRecord(TimestampMixin, Base):
+    __tablename__ = "verification_records"
+
+    id = Column(Integer, primary_key=True)
+    form_id = Column(Integer, ForeignKey("approval_forms.id"), nullable=False)
+    verifier_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    status = Column(Enum(VerificationStatus), default=VerificationStatus.PENDING, nullable=False)
+    verified_at = Column(DateTime)
+    comments = Column(String(255))
+
+    form = relationship("ApprovalForm", back_populates="verification_records")
+    verifier = relationship("User", back_populates="verification_records")
+
+    __table_args__ = (
+        Index("ix_verify_form", "form_id"),
+        Index("ix_verify_verifier", "verifier_id"),
+    )


### PR DESCRIPTION
## Summary
- scaffold SQLAlchemy models for admins, users, organizations, departments, templates, forms, records and notifications
- add timestamp mixin and basic indexes to support approval flow, delegation and push notifications

## Testing
- `python -m py_compile models/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68919e591c7483278c82774dc08acfc8