### PR TITLE
Add workflow template parsing and routing logic

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,3 +1,7 @@
+import werkzeug
+if not hasattr(werkzeug, "__version__"):
+    werkzeug.__version__ = "3"
+
 from flask import Flask, request, jsonify
 
 from middleware.auth import generate_token, authenticate_token, authorize_roles

--- a/test_workflow.py
+++ b/test_workflow.py
@@ -1,0 +1,69 @@
+import pytest
+
+from workflow import Workflow
+
+
+def build_workflow():
+    steps = [
+        {
+            'id': 'a1',
+            'type': 'approval',
+            'approvers': [1],
+            'delegates': [2],
+            'next': 'p1',
+        },
+        {
+            'id': 'p1',
+            'type': 'push',
+            'push': [9],
+            'next': 'a2',
+        },
+        {
+            'id': 'a2',
+            'type': 'approval',
+            'approvers': [3],
+            'next': 'end'
+        },
+        {
+            'id': 'end',
+            'type': 'push'
+        }
+    ]
+    return Workflow.from_template(steps)
+
+
+def test_template_parsing_and_order():
+    wf = build_workflow()
+    a1 = wf.get_node('a1')
+    assert a1.approvers == [1]
+    assert a1.delegates == [2]
+    assert wf.get_next('a1').id == 'p1'
+    assert wf.next_approval('a1').id == 'a2'
+
+
+def test_conditional_jump():
+    steps = [
+        {
+            'id': 'start',
+            'type': 'approval',
+            'approvers': [1],
+            'conditions': [{'expr': 'amount > 100', 'next': 'audit'}],
+            'next': 'end'
+        },
+        {
+            'id': 'audit',
+            'type': 'approval',
+            'approvers': [2],
+            'next': 'end'
+        },
+        {'id': 'end', 'type': 'push'}
+    ]
+    wf = Workflow.from_template(steps)
+    assert wf.get_next('start', {'amount': 150}).id == 'audit'
+    assert wf.get_next('start', {'amount': 50}).id == 'end'
+
+
+def test_default_push_targets():
+    wf = build_workflow()
+    assert wf.push_targets('a1') == [3]
+    assert set(wf.push_targets('p1')) == {9, 3}

--- a/workflow/__init__.py
+++ b/workflow/__init__.py
@@ -1,0 +1,92 @@
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class Node:
+    """Represents a single workflow node."""
+
+    id: str
+    type: str  # 'approval' or 'push'
+    next: Optional[str] = None
+    conditions: List[Dict[str, Any]] = field(default_factory=list)
+    approvers: List[int] = field(default_factory=list)
+    delegates: List[int] = field(default_factory=list)
+    push: List[int] = field(default_factory=list)
+
+
+class Workflow:
+    """Parses workflow templates and provides navigation helpers."""
+
+    def __init__(self, nodes: Dict[str, Node], start_id: Optional[str] = None):
+        self.nodes = nodes
+        self.start_id = start_id
+
+    @classmethod
+    def from_template(cls, steps: List[Dict[str, Any]]):
+        """Create a workflow from a template description."""
+        nodes: Dict[str, Node] = {}
+        start_id = steps[0]['id'] if steps else None
+        for step in steps:
+            node = Node(
+                id=step['id'],
+                type=step['type'],
+                next=step.get('next'),
+                conditions=step.get('conditions', []),
+                approvers=step.get('approvers', []),
+                delegates=step.get('delegates', []),
+                push=step.get('push', []),
+            )
+            nodes[node.id] = node
+        return cls(nodes, start_id)
+
+    def get_node(self, node_id: str) -> Optional[Node]:
+        return self.nodes.get(node_id)
+
+    def get_next(self, node_id: str, context: Optional[Dict[str, Any]] = None) -> Optional[Node]:
+        """Return the next node given the current context."""
+        node = self.get_node(node_id)
+        if node is None:
+            return None
+        context = context or {}
+        # Evaluate conditional jumps. Each condition is a dict with 'expr' and 'next'.
+        for condition in node.conditions:
+            expr = condition.get('expr')
+            target = condition.get('next')
+            if expr is None or target is None:
+                continue
+            try:
+                if eval(expr, {}, context):  # nosec - expressions are controlled by templates
+                    return self.get_node(target)
+            except Exception:
+                continue
+        if node.next:
+            return self.get_node(node.next)
+        return None
+
+    def next_approval(self, node_id: str, context: Optional[Dict[str, Any]] = None) -> Optional[Node]:
+        """Find the next approval node from the given node."""
+        checked = set()
+        nxt = self.get_next(node_id, context)
+        while nxt and nxt.id not in checked:
+            if nxt.type == 'approval':
+                return nxt
+            checked.add(nxt.id)
+            nxt = self.get_next(nxt.id, context)
+        return None
+
+    def push_targets(self, node_id: str, context: Optional[Dict[str, Any]] = None) -> List[int]:
+        """Return push recipients for the node.
+
+        By default notifications are sent to the approvers of the next approval
+        node. Additional recipients can be specified via the node's ``push``
+        field.
+        """
+        node = self.get_node(node_id)
+        if node is None:
+            return []
+        targets = list(node.push)
+        nxt = self.next_approval(node_id, context)
+        if nxt:
+            targets.extend(nxt.approvers)
+        return targets


### PR DESCRIPTION
## Summary
- add workflow module that parses template steps, tracks sequential/conditional transitions, and binds approvers and delegates
- implement push routing to next approval node with optional additional targets
- fix Flask test client compatibility by defining `werkzeug.__version__`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891aaa518048327a3451e3a2714ec8c