### PR TITLE
Add approval form controller with submission tracking

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,8 +5,10 @@ if not hasattr(werkzeug, "__version__"):
 from flask import Flask, request, jsonify
 
 from middleware.auth import generate_token, authenticate_token, authorize_roles
+from controllers.approval import bp as approval_bp, reset_data as reset_approval_data
 
 app = Flask(__name__)
+app.register_blueprint(approval_bp)
 
 
 def reset_data():
@@ -17,6 +19,7 @@ def reset_data():
         {'id': 1, 'username': 'admin', 'password': 'admin', 'role': 'admin', 'org_id': 1, 'dept_id': 1},
         {'id': 2, 'username': 'user', 'password': 'user', 'role': 'user', 'org_id': 1, 'dept_id': 1}
     ]
+    reset_approval_data()
 
 
 reset_data()

--- a/controllers/approval.py
+++ b/controllers/approval.py
@@ -1,0 +1,86 @@
+from datetime import datetime
+from flask import Blueprint, jsonify, request
+
+from middleware.auth import authenticate_token
+
+bp = Blueprint('approval', __name__, url_prefix='/approvals')
+
+approval_forms = []
+submission_records = []
+_next_id = 1
+_next_code = 1
+
+def reset_data():
+    global approval_forms, submission_records, _next_id, _next_code
+    approval_forms = []
+    submission_records = []
+    _next_id = 1
+    _next_code = 1
+
+
+def _find_form(form_id):
+    return next((f for f in approval_forms if f['id'] == form_id), None)
+
+
+@bp.post('')
+@authenticate_token
+def create_form():
+    global _next_id, _next_code
+    payload = request.get_json() or {}
+    form = {
+        'id': _next_id,
+        'data': payload.get('data', {}),
+        'applicant_id': request.user['id'],
+        'org_id': request.user.get('org_id'),
+        'dept_id': request.user.get('dept_id'),
+        'status': 'draft',
+        'submitted_at': None,
+        'code': f'APP{_next_code:06d}'
+    }
+    approval_forms.append(form)
+    _next_id += 1
+    _next_code += 1
+    return jsonify(form), 201
+
+
+@bp.put('/<int:form_id>')
+@authenticate_token
+def update_form(form_id):
+    form = _find_form(form_id)
+    if not form:
+        return '', 404
+    if form['applicant_id'] != request.user['id'] or form['status'] != 'draft':
+        return '', 403
+    payload = request.get_json() or {}
+    if 'data' in payload:
+        form['data'] = payload['data']
+    return jsonify(form)
+
+
+@bp.post('/<int:form_id>/submit')
+@authenticate_token
+def submit_form(form_id):
+    form = _find_form(form_id)
+    if not form:
+        return '', 404
+    now = datetime.utcnow().isoformat()
+    form['status'] = 'submitted'
+    form['submitted_at'] = now
+    record = {
+        'id': len(submission_records) + 1,
+        'form_id': form_id,
+        'submitter_id': request.user['id'],
+        'submitted_at': now
+    }
+    submission_records.append(record)
+    return jsonify(form)
+
+
+@bp.post('/<int:form_id>/reject')
+@authenticate_token
+def reject_form(form_id):
+    form = _find_form(form_id)
+    if not form:
+        return '', 404
+    form['status'] = 'rejected'
+    return jsonify(form)

--- a/middleware/auth.py
+++ b/middleware/auth.py
@@ -11,6 +11,8 @@ def generate_token(user):
     payload = {
         'id': user['id'],
         'role': user['role'],
+        'org_id': user.get('org_id'),
+        'dept_id': user.get('dept_id'),
         'exp': datetime.datetime.utcnow() + datetime.timedelta(hours=1)
     }
     return jwt.encode(payload, SECRET, algorithm='HS256')

--- a/test_approval_controller.py
+++ b/test_approval_controller.py
@@ -1,0 +1,49 @@
+import pytest
+from app import app, reset_data
+from controllers import approval
+
+
+@pytest.fixture(autouse=True)
+def run_around_tests():
+    reset_data()
+    approval.reset_data()
+    yield
+
+
+def token(client, username='admin', password='admin'):
+    resp = client.post('/login', json={'username': username, 'password': password})
+    assert resp.status_code == 200
+    return resp.get_json()['token']
+
+
+def test_create_submit_reject_flow():
+    client = app.test_client()
+    t = token(client)
+    # create
+    resp = client.post('/approvals', json={'data': {'a': 1}}, headers={'Authorization': f'Bearer {t}'})
+    assert resp.status_code == 201
+    form = resp.get_json()
+    assert form['applicant_id'] == 1
+    assert form['org_id'] == 1
+    assert form['dept_id'] == 1
+    assert form['code']
+    form_id = form['id']
+    # update
+    resp = client.put(f'/approvals/{form_id}', json={'data': {'a': 2}}, headers={'Authorization': f'Bearer {t}'})
+    assert resp.status_code == 200
+    assert resp.get_json()['data']['a'] == 2
+    # submit
+    resp = client.post(f'/approvals/{form_id}/submit', headers={'Authorization': f'Bearer {t}'})
+    assert resp.status_code == 200
+    submitted = resp.get_json()
+    assert submitted['status'] == 'submitted'
+    assert submitted['submitted_at']
+    assert len(approval.submission_records) == 1
+    record = approval.submission_records[0]
+    assert record['form_id'] == form_id
+    assert record['submitter_id'] == 1
+    assert record['submitted_at']
+    # reject
+    resp = client.post(f'/approvals/{form_id}/reject', headers={'Authorization': f'Bearer {t}'})
+    assert resp.status_code == 200
+    assert resp.get_json()['status'] == 'rejected'


### PR DESCRIPTION
## Summary
- implement approval controller with create, update, submit, and reject endpoints
- log submission time, initiator, org/department, and code
- store each submission in in-memory SubmissionRecord and register blueprint

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891abe4d9408327897aca7477d0c2cf