### PR TITLE
Add statistics endpoints with filtering and export

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,10 +7,12 @@ from flask import Flask, request, jsonify
 from middleware.auth import generate_token, authenticate_token, authorize_roles
 from controllers.approval import bp as approval_bp, reset_data as reset_approval_data
 from controllers.verification import bp as verification_bp
+from controllers.statistics import bp as statistics_bp
 
 app = Flask(__name__)
 app.register_blueprint(approval_bp)
 app.register_blueprint(verification_bp)
+app.register_blueprint(statistics_bp)
 
 
 def reset_data():

--- a/controllers/statistics.py
+++ b/controllers/statistics.py
@@ -1,0 +1,191 @@
+from datetime import datetime
+import csv
+import io
+
+from flask import Blueprint, request, jsonify, send_file
+
+from middleware.auth import authenticate_token
+from . import approval
+
+try:  # optional excel support
+    from openpyxl import Workbook
+except Exception:  # pragma: no cover - optional dependency
+    Workbook = None
+
+bp = Blueprint('statistics', __name__, url_prefix='/statistics')
+
+
+def _parse_date(value):
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def _filter_forms(forms, status=None, start=None, end=None):
+    result = []
+    for form in forms:
+        if status and form.get('status') != status:
+            continue
+        submitted_at = form.get('submitted_at')
+        if start and (not submitted_at or datetime.fromisoformat(submitted_at) < start):
+            continue
+        if end and (not submitted_at or datetime.fromisoformat(submitted_at) > end):
+            continue
+        result.append(form)
+    return result
+
+
+def _paginate(items, page, per_page):
+    start = (page - 1) * per_page
+    end = start + per_page
+    return items[start:end]
+
+
+def _export_approvals(data, fmt):
+    headers = ['id', 'code', 'status', 'amount']
+    rows = [
+        [f.get('id'), f.get('code'), f.get('status'), f.get('data', {}).get('amount')] for f in data
+    ]
+    if fmt == 'csv':
+        sio = io.StringIO()
+        writer = csv.writer(sio)
+        writer.writerow(headers)
+        writer.writerows(rows)
+        output = io.BytesIO(sio.getvalue().encode('utf-8'))
+        return send_file(
+            output,
+            mimetype='text/csv',
+            as_attachment=True,
+            download_name='approvals.csv',
+        )
+    if fmt == 'excel':
+        if not Workbook:
+            return jsonify({'error': 'excel export not supported'}), 501
+        wb = Workbook()
+        ws = wb.active
+        ws.append(headers)
+        for row in rows:
+            ws.append(row)
+        output = io.BytesIO()
+        wb.save(output)
+        output.seek(0)
+        return send_file(
+            output,
+            mimetype='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            as_attachment=True,
+            download_name='approvals.xlsx',
+        )
+    return '', 400
+
+
+@bp.get('/approvals')
+@authenticate_token
+def approval_stats():
+    status = request.args.get('status')
+    start = _parse_date(request.args.get('start_date'))
+    end = _parse_date(request.args.get('end_date'))
+
+    filtered = _filter_forms(approval.approval_forms, status, start, end)
+    total_amount = sum(f.get('data', {}).get('amount', 0) for f in filtered)
+
+    export = request.args.get('export')
+    if export:
+        return _export_approvals(filtered, export)
+
+    page = int(request.args.get('page', 1))
+    per_page = int(request.args.get('per_page', 10))
+    items = _paginate(filtered, page, per_page)
+
+    return jsonify(
+        {
+            'total': len(filtered),
+            'page': page,
+            'per_page': per_page,
+            'total_amount': total_amount,
+            'items': items,
+        }
+    )
+
+
+def _filter_verifications(records, status=None, start=None, end=None):
+    result = []
+    for record in records:
+        if status and record.get('status') != status:
+            continue
+        acted_at = record.get('verified_at')
+        if start and (not acted_at or datetime.fromisoformat(acted_at) < start):
+            continue
+        if end and (not acted_at or datetime.fromisoformat(acted_at) > end):
+            continue
+        form = next((f for f in approval.approval_forms if f['id'] == record['form_id']), {})
+        merged = dict(record)
+        merged['amount'] = form.get('data', {}).get('amount', 0)
+        result.append(merged)
+    return result
+
+
+def _export_verifications(data, fmt):
+    headers = ['id', 'form_id', 'status', 'verified_at', 'amount']
+    rows = [[r.get(h) for h in headers] for r in data]
+    if fmt == 'csv':
+        sio = io.StringIO()
+        writer = csv.writer(sio)
+        writer.writerow(headers)
+        writer.writerows(rows)
+        output = io.BytesIO(sio.getvalue().encode('utf-8'))
+        return send_file(
+            output,
+            mimetype='text/csv',
+            as_attachment=True,
+            download_name='verifications.csv',
+        )
+    if fmt == 'excel':
+        if not Workbook:
+            return jsonify({'error': 'excel export not supported'}), 501
+        wb = Workbook()
+        ws = wb.active
+        ws.append(headers)
+        for row in rows:
+            ws.append(row)
+        output = io.BytesIO()
+        wb.save(output)
+        output.seek(0)
+        return send_file(
+            output,
+            mimetype='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            as_attachment=True,
+            download_name='verifications.xlsx',
+        )
+    return '', 400
+
+
+@bp.get('/verification')
+@authenticate_token
+def verification_stats():
+    status = request.args.get('status')
+    start = _parse_date(request.args.get('start_date'))
+    end = _parse_date(request.args.get('end_date'))
+
+    filtered = _filter_verifications(approval.verification_records, status, start, end)
+    total_amount = sum(r.get('amount', 0) for r in filtered)
+
+    export = request.args.get('export')
+    if export:
+        return _export_verifications(filtered, export)
+
+    page = int(request.args.get('page', 1))
+    per_page = int(request.args.get('per_page', 10))
+    items = _paginate(filtered, page, per_page)
+
+    return jsonify(
+        {
+            'total': len(filtered),
+            'page': page,
+            'per_page': per_page,
+            'total_amount': total_amount,
+            'items': items,
+        }
+    )

--- a/test_statistics_controller.py
+++ b/test_statistics_controller.py
@@ -1,0 +1,97 @@
+import pytest
+from app import app, reset_data
+from controllers import approval
+
+
+@pytest.fixture(autouse=True)
+def run_around_tests():
+    reset_data()
+    approval.reset_data()
+    yield
+
+
+def token(client):
+    resp = client.post('/login', json={'username': 'admin', 'password': 'admin'})
+    assert resp.status_code == 200
+    return resp.get_json()['token']
+
+
+def test_statistics_queries_and_export():
+    client = app.test_client()
+    t = token(client)
+
+    # approved form
+    resp = client.post(
+        '/approvals',
+        json={'data': {'amount': 100}},
+        headers={'Authorization': f'Bearer {t}'},
+    )
+    form1 = resp.get_json()
+    form1_id = form1['id']
+    client.post(f'/approvals/{form1_id}/submit', headers={'Authorization': f'Bearer {t}'})
+    client.post(
+        f'/approvals/{form1_id}/approve', json={}, headers={'Authorization': f'Bearer {t}'}
+    )
+
+    # form requiring verification
+    resp = client.post(
+        '/approvals',
+        json={'data': {'amount': 70, 'requires_verification': True}},
+        headers={'Authorization': f'Bearer {t}'},
+    )
+    form2 = resp.get_json()
+    form2_id = form2['id']
+    code2 = form2['code']
+    client.post(f'/approvals/{form2_id}/submit', headers={'Authorization': f'Bearer {t}'})
+    client.post(
+        f'/approvals/{form2_id}/approve', json={}, headers={'Authorization': f'Bearer {t}'}
+    )
+    client.post(
+        f'/verification/{code2}',
+        json={'result': 'verified'},
+        headers={'Authorization': f'Bearer {t}'},
+    )
+
+    # overall statistics
+    resp = client.get('/statistics/approvals', headers={'Authorization': f'Bearer {t}'})
+    assert resp.status_code == 200
+    stats = resp.get_json()
+    assert stats['total'] == 2
+    assert stats['total_amount'] == 170
+
+    # filter approved
+    resp = client.get(
+        '/statistics/approvals?status=approved',
+        headers={'Authorization': f'Bearer {t}'},
+    )
+    stats = resp.get_json()
+    assert stats['total'] == 1
+    assert stats['total_amount'] == 100
+
+    # pagination
+    resp = client.get(
+        '/statistics/approvals?per_page=1&page=1',
+        headers={'Authorization': f'Bearer {t}'},
+    )
+    stats = resp.get_json()
+    assert stats['total'] == 2
+    assert len(stats['items']) == 1
+
+    # export csv
+    resp = client.get(
+        '/statistics/approvals?status=approved&export=csv',
+        headers={'Authorization': f'Bearer {t}'},
+    )
+    assert resp.status_code == 200
+    assert resp.mimetype == 'text/csv'
+    assert b'amount' in resp.data
+
+    # verification statistics
+    resp = client.get(
+        '/statistics/verification?status=verified',
+        headers={'Authorization': f'Bearer {t}'},
+    )
+    assert resp.status_code == 200
+    vstats = resp.get_json()
+    assert vstats['total'] == 1
+    assert vstats['total_amount'] == 70


### PR DESCRIPTION
## Summary
- add statistics blueprint to query approval forms and verification records with total amount calculations
- support pagination and CSV/Excel export for reporting
- wire statistics routes into application and cover with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892af25078c8327860c9ac989065fdc