### PR TITLE
Implement notifications module with workflow integration

### DIFF
--- a/notifications/__init__.py
+++ b/notifications/__init__.py
@@ -1,0 +1,31 @@
+sent_notifications = []
+
+
+def send(recipients, message, channels=None):
+    """Send a notification to one or more recipients.
+
+    Parameters
+    ----------
+    recipients : list[int]
+        User IDs of the recipients.
+    message : str
+        Message body of the notification.
+    channels : list[str], optional
+        Channels to send through. Supported channels are ``in_app``, ``sms``
+        and ``third_party``. Defaults to ["in_app"].
+    """
+    channels = channels or ["in_app"]
+    for rid in recipients:
+        for ch in channels:
+            sent_notifications.append(
+                {
+                    "recipient_id": rid,
+                    "channel": ch,
+                    "message": message,
+                }
+            )
+
+
+def reset():
+    """Clear recorded notifications (useful for tests)."""
+    sent_notifications.clear()

--- a/test_notifications.py
+++ b/test_notifications.py
@@ -1,0 +1,49 @@
+import pytest
+
+from notifications import reset, send, sent_notifications
+from workflow import Workflow
+
+
+def build_workflow():
+    steps = [
+        {
+            'id': 'a1',
+            'type': 'approval',
+            'approvers': [1],
+            'next': 'p1',
+        },
+        {
+            'id': 'p1',
+            'type': 'push',
+            'push': [9],
+            'next': 'a2',
+        },
+        {
+            'id': 'a2',
+            'type': 'approval',
+            'approvers': [3],
+            'next': 'end'
+        },
+        {
+            'id': 'end',
+            'type': 'push'
+        }
+    ]
+    return Workflow.from_template(steps)
+
+
+def test_send_multiple_channels():
+    reset()
+    send([1], 'hello', channels=['in_app', 'sms', 'third_party'])
+    assert {n['channel'] for n in sent_notifications} == {'in_app', 'sms', 'third_party'}
+    assert all(n['recipient_id'] == 1 for n in sent_notifications)
+
+
+def test_workflow_notify_next_targets():
+    wf = build_workflow()
+    reset()
+    wf.notify('a1', 'step done')
+    assert {n['recipient_id'] for n in sent_notifications} == {3}
+    reset()
+    wf.notify('p1', 'pushed')
+    assert {n['recipient_id'] for n in sent_notifications} == {9, 3}

--- a/workflow/__init__.py
+++ b/workflow/__init__.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
+from notifications import send as send_notification
+
 
 @dataclass
 class Node:
@@ -90,3 +92,14 @@ class Workflow:
         if nxt:
             targets.extend(nxt.approvers)
         return targets
+
+    def notify(self, node_id: str, message: str, context: Optional[Dict[str, Any]] = None,
+               channels: Optional[List[str]] = None) -> None:
+        """Send a notification after the specified node is completed.
+
+        Notifications are delivered to the next approver(s) or any additional
+        push targets defined for the node.
+        """
+        recipients = self.push_targets(node_id, context)
+        if recipients:
+            send_notification(recipients, message, channels)


### PR DESCRIPTION
## Summary
- add notifications module supporting in-app, SMS, and third-party channels
- integrate workflow with notification dispatch to next approvers or push targets
- cover notification channels and workflow-triggered notifications in tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892b0afc2188327821a1ce8ced721ae