### PR TITLE
feat: add admin template and verifier management

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,7 +5,8 @@ if not hasattr(werkzeug, "__version__"):
 from flask import Flask, request, jsonify
 
 from middleware.auth import generate_token, authenticate_token, authorize_roles
-from controllers.approval import bp as approval_bp, reset_data as reset_approval_data
+from controllers import approval, verification
+from controllers.approval import bp as approval_bp
 from controllers.verification import bp as verification_bp
 from controllers.statistics import bp as statistics_bp
 
@@ -16,14 +17,16 @@ app.register_blueprint(statistics_bp)
 
 
 def reset_data():
-    global organizations, departments, users
+    global organizations, departments, users, templates
     organizations = [{'id': 1, 'name': 'Org1'}]
     departments = [{'id': 1, 'name': 'Dept1', 'org_id': 1}]
     users = [
         {'id': 1, 'username': 'admin', 'password': 'admin', 'role': 'admin', 'org_id': 1, 'dept_id': 1},
         {'id': 2, 'username': 'user', 'password': 'user', 'role': 'user', 'org_id': 1, 'dept_id': 1}
     ]
-    reset_approval_data()
+    templates = []
+    approval.reset_data()
+    verification.reset_data()
 
 
 reset_data()
@@ -156,6 +159,70 @@ def update_dept(dept_id):
 def delete_dept(dept_id):
     global departments
     departments = [d for d in departments if d['id'] != dept_id]
+    return '', 204
+
+
+@app.get('/admin/templates')
+@authenticate_token
+@authorize_roles('admin')
+def list_templates():
+    return jsonify(templates)
+
+
+@app.post('/admin/templates')
+@authenticate_token
+@authorize_roles('admin')
+def create_template():
+    tpl = request.get_json() or {}
+    tpl['id'] = len(templates) + 1
+    templates.append(tpl)
+    return jsonify(tpl), 201
+
+
+@app.put('/admin/templates/<int:template_id>')
+@authenticate_token
+@authorize_roles('admin')
+def update_template(template_id):
+    tpl = next((t for t in templates if t['id'] == template_id), None)
+    if not tpl:
+        return '', 404
+    tpl.update(request.get_json() or {})
+    return jsonify(tpl)
+
+
+@app.delete('/admin/templates/<int:template_id>')
+@authenticate_token
+@authorize_roles('admin')
+def delete_template(template_id):
+    global templates
+    templates = [t for t in templates if t['id'] != template_id]
+    return '', 204
+
+
+@app.get('/admin/verifiers')
+@authenticate_token
+@authorize_roles('admin')
+def list_verifiers():
+    return jsonify(sorted(verification.authorized_verifiers))
+
+
+@app.post('/admin/verifiers')
+@authenticate_token
+@authorize_roles('admin')
+def add_verifier():
+    data = request.get_json() or {}
+    uid = data.get('user_id')
+    if uid is None:
+        return '', 400
+    verification.authorized_verifiers.add(uid)
+    return jsonify({'user_id': uid}), 201
+
+
+@app.delete('/admin/verifiers/<int:user_id>')
+@authenticate_token
+@authorize_roles('admin')
+def remove_verifier(user_id):
+    verification.authorized_verifiers.discard(user_id)
     return '', 204
 
 

--- a/controllers/verification.py
+++ b/controllers/verification.py
@@ -8,6 +8,17 @@ from . import approval
 bp = Blueprint('verification', __name__, url_prefix='/verification')
 
 
+authorized_verifiers = set()
+
+
+def reset_data():
+    global authorized_verifiers
+    authorized_verifiers = {1}  # admin can verify by default
+
+
+reset_data()
+
+
 def _find_form_by_code(code):
     return next((f for f in approval.approval_forms if f.get('code') == code), None)
 
@@ -31,6 +42,8 @@ def verify_form(code):
     form = _find_form_by_code(code)
     if not form:
         return '', 404
+    if request.user['id'] not in authorized_verifiers:
+        return '', 403
     payload = request.get_json() or {}
     result = payload.get('result', 'verified')
     comments = payload.get('comments')

--- a/test_app.py
+++ b/test_app.py
@@ -49,3 +49,51 @@ def test_user_cannot_create_user():
         headers={'Authorization': f'Bearer {t}'}
     )
     assert resp.status_code == 403
+
+
+def test_admin_can_manage_templates():
+    client = app.test_client()
+    t = token(client, 'admin', 'admin')
+    resp = client.post(
+        '/admin/templates',
+        json={'name': 'T1', 'steps': ['a', 'b']},
+        headers={'Authorization': f'Bearer {t}'},
+    )
+    assert resp.status_code == 201
+    tpl = resp.get_json()
+    tid = tpl['id']
+    resp = client.put(
+        f'/admin/templates/{tid}',
+        json={'verifier_id': 2},
+        headers={'Authorization': f'Bearer {t}'},
+    )
+    assert resp.status_code == 200
+    assert resp.get_json()['verifier_id'] == 2
+    resp = client.get('/admin/templates', headers={'Authorization': f'Bearer {t}'})
+    assert resp.status_code == 200
+    assert any(t['id'] == tid for t in resp.get_json())
+    resp = client.delete(f'/admin/templates/{tid}', headers={'Authorization': f'Bearer {t}'})
+    assert resp.status_code == 204
+
+
+def test_admin_can_manage_verifiers():
+    client = app.test_client()
+    t = token(client, 'admin', 'admin')
+    resp = client.post('/admin/verifiers', json={'user_id': 2}, headers={'Authorization': f'Bearer {t}'})
+    assert resp.status_code == 201
+    resp = client.get('/admin/verifiers', headers={'Authorization': f'Bearer {t}'})
+    assert resp.status_code == 200
+    assert 2 in resp.get_json()
+    resp = client.delete('/admin/verifiers/2', headers={'Authorization': f'Bearer {t}'})
+    assert resp.status_code == 204
+
+
+def test_user_cannot_create_template():
+    client = app.test_client()
+    t = token(client, 'user', 'user')
+    resp = client.post(
+        '/admin/templates',
+        json={'name': 'T2', 'steps': []},
+        headers={'Authorization': f'Bearer {t}'},
+    )
+    assert resp.status_code == 403


### PR DESCRIPTION
## Summary
- allow admins to manage approval templates with CRUD endpoints
- add admin APIs to assign and revoke verification staff
- restrict verification endpoints to authorized verifiers

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6892b2d869fc8327a95ba715a43b8e48