### PR TITLE
Unify workflow template structure and validation

### DIFF
--- a/controllers/approval.py
+++ b/controllers/approval.py
@@ -65,8 +65,6 @@ def _can_approve(user_id, template):
         return False
     
     nodes = template.get('workflow_config', {}).get('nodes', [])
-    if not nodes:
-        nodes = template.get('steps', [])
     for node in nodes:
         if node.get('type') == 'approval':
             # 检查是否是审批人
@@ -193,13 +191,9 @@ def submit_form(form_id):
 
     # 创建工作流实例
     template = _find_template(form.get('template_id'))
-    steps = None
-    if template:
-        steps = template.get('steps')
-        if not steps:
-            steps = template.get('workflow_config', {}).get('nodes')
-    if steps:
-        wf = Workflow.from_template(steps)
+    nodes = template.get('workflow_config', {}).get('nodes') if template else None
+    if nodes:
+        wf = Workflow.from_template(nodes)
         inst = WorkflowInstance(wf, context=form.get('data'))
         workflow_instances[form_id] = inst
         node = inst.current_node()

--- a/static/admin.html
+++ b/static/admin.html
@@ -739,14 +739,16 @@
         const templates = await response.json();
         
         const tplList = document.getElementById('tplList');
-        tplList.innerHTML = templates.map(tpl => `
+        tplList.innerHTML = templates.map(tpl => {
+          const nodes = (tpl.workflow_config && tpl.workflow_config.nodes) || tpl.steps || [];
+          return `
           <li>
-            <span>${tpl.id}: ${tpl.name || 'template'} (${(tpl.steps || []).length} 步骤)</span>
+            <span>${tpl.id}: ${tpl.name || 'template'} (${nodes.length} 步骤)</span>
             <div class="actions">
               <button class="btn btn-sm btn-danger" onclick="deleteTemplate(${tpl.id})">删除</button>
             </div>
           </li>
-        `).join('');
+        `}).join('');
       } catch (error) {
         showAlert('加载模板列表失败', 'error');
       }

--- a/test_app.py
+++ b/test_app.py
@@ -56,11 +56,12 @@ def test_admin_can_manage_templates():
     t = token(client, 'admin', 'admin')
     resp = client.post(
         '/admin/templates',
-        json={'name': 'T1', 'steps': ['a', 'b']},
+        json={'name': 'T1', 'steps': [{'id': 'a', 'type': 'approval'}, {'id': 'b', 'type': 'approval'}]},
         headers={'Authorization': f'Bearer {t}'},
     )
     assert resp.status_code == 201
     tpl = resp.get_json()
+    assert tpl['workflow_config']['nodes'][0]['id'] == 'a'
     tid = tpl['id']
     resp = client.put(
         f'/admin/templates/{tid}',

--- a/test_approval_controller.py
+++ b/test_approval_controller.py
@@ -143,10 +143,12 @@ def test_workflow_execution_flow():
     approval.workflow_templates.append({
         'id': 1,
         'name': 'two-step',
-        'steps': [
-            {'id': 'n1', 'type': 'approval', 'approvers': [1], 'next': 'n2'},
-            {'id': 'n2', 'type': 'approval', 'approvers': [1]},
-        ],
+        'workflow_config': {
+            'nodes': [
+                {'id': 'n1', 'type': 'approval', 'approvers': [1], 'next': 'n2'},
+                {'id': 'n2', 'type': 'approval', 'approvers': [1]},
+            ]
+        },
     })
     # create form using template
     resp = client.post(
@@ -197,10 +199,12 @@ def test_workflow_rejection_flow():
     approval.workflow_templates.append({
         'id': 1,
         'name': 'two-step',
-        'steps': [
-            {'id': 'n1', 'type': 'approval', 'approvers': [1], 'next': 'n2'},
-            {'id': 'n2', 'type': 'approval', 'approvers': [1]},
-        ],
+        'workflow_config': {
+            'nodes': [
+                {'id': 'n1', 'type': 'approval', 'approvers': [1], 'next': 'n2'},
+                {'id': 'n2', 'type': 'approval', 'approvers': [1]},
+            ]
+        },
     })
     resp = client.post(
         '/approvals',
@@ -240,6 +244,7 @@ def test_actor_scope_and_resubmit():
     )
     assert resp.status_code == 201
     tpl = resp.get_json()
+    assert tpl['workflow_config']['nodes'][0]['approvers'] == [2]
     # admin creates form and submits
     resp = client.post(
         '/approvals',


### PR DESCRIPTION
## Summary
- standardize workflow templates to use `workflow_config.nodes`
- validate and normalize template payloads in admin endpoints
- update admin UI and tests for unified template field

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68975ac756fc8327ad1cdac4fd30e9bd