### PR TITLE
Refresh approval template references after create/delete

### DIFF
--- a/app.py
+++ b/app.py
@@ -232,6 +232,7 @@ def create_template():
         return '', 400
     tpl['id'] = max([t['id'] for t in data['templates']], default=0) + 1
     data['templates'].append(tpl)
+    approval._refresh_refs()
     storage.save()
     return jsonify(tpl), 201
 
@@ -257,7 +258,12 @@ def update_template(template_id):
 @authenticate_token
 @authorize_roles('admin')
 def delete_template(template_id):
-    data['templates'] = [t for t in data['templates'] if t['id'] != template_id]
+    templates = data['templates']
+    for i, t in enumerate(templates):
+        if t['id'] == template_id:
+            del templates[i]
+            break
+    approval._refresh_refs()
     storage.save()
     return '', 204
 

--- a/test_app.py
+++ b/test_app.py
@@ -1,6 +1,7 @@
 import pytest
 
 from app import app, reset_data
+from controllers import approval
 
 
 @pytest.fixture(autouse=True)
@@ -75,6 +76,7 @@ def test_admin_can_manage_templates():
     assert any(t['id'] == tid for t in resp.get_json())
     resp = client.delete(f'/admin/templates/{tid}', headers={'Authorization': f'Bearer {t}'})
     assert resp.status_code == 204
+    assert all(t['id'] != tid for t in approval.workflow_templates)
 
 
 def test_admin_can_manage_verifiers():


### PR DESCRIPTION
## Summary
- Refresh controllers.approval references after creating or deleting workflow templates
- Delete templates in-place to avoid stale references
- Test that deleting a template removes it from `approval.workflow_templates`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68975c71fc3c8327b3a85ef322b17a15